### PR TITLE
Refactor the implementation and implement ReadDirFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/jhchabran/gistfs"
 )
@@ -65,6 +66,17 @@ func main() {
 	}
 
 	fmt.Println(string(b))
+
+	// --- ReadDir API
+	// there is only one directory in a gistfile, the root dir "."
+	files, err := gfs.ReadDir(".")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, entry := range files {
+		fmt.Println(entry.Name())
+	}
 
 	// --- Serve the files from the gists over http
 	http.ListenAndServe(":8080", http.FileServer(http.FS(gfs)))

--- a/gistfs_test.go
+++ b/gistfs_test.go
@@ -277,6 +277,19 @@ func TestReadDir(t *testing.T) {
 		}
 	})
 
+	t.Run("NOK non existing dir", func(t *testing.T) {
+		tests := []string{"/", "non-existing/", "..", "../"}
+
+		for _, test := range tests {
+			_, err := gfs.Open(test)
+
+			var pathError *fs.PathError
+			if !errors.As(err, &pathError) {
+				t.Fatalf("Reading a non existing directory %#v, got %#v error, want %T", test, err, &fs.PathError{})
+			}
+		}
+	})
+
 	t.Run("OK subsequent reads", func(t *testing.T) {
 		file, err := gfs.Open(".")
 		if err != nil {
@@ -343,8 +356,9 @@ func TestReadDir(t *testing.T) {
 
 		_, err = dir.ReadDir(-1)
 
-		if _, ok := err.(*fs.PathError); !ok {
-			t.Fatalf("Reading directory on a file, got %#v error, want %#v", err, &fs.PathError{})
+		var pathError *fs.PathError
+		if !errors.As(err, &pathError) {
+			t.Fatalf("Reading directory on a file, got %#v error, want a %T", err, &fs.PathError{})
 		}
 	})
 
@@ -362,8 +376,9 @@ func TestReadDir(t *testing.T) {
 		b := make([]byte, 1)
 		_, err = dir.Read(b)
 
-		if _, ok := err.(*fs.PathError); !ok {
-			t.Fatalf("Reading bytes on a directory, got %#v error, want %#v", err, &fs.PathError{})
+		var pathError *fs.PathError
+		if !errors.As(err, &pathError) {
+			t.Fatalf("Reading bytes on a directory, got %#v error, want %T", err, &fs.PathError{})
 		}
 	})
 

--- a/gistfs_test.go
+++ b/gistfs_test.go
@@ -65,7 +65,7 @@ func TestOpen(t *testing.T) {
 		for _, test := range tests {
 			f, err := gfs.Open(test.name)
 
-			if err != test.err {
+			if test.err != nil && !errors.Is(err, test.err) {
 				t.Fatalf("Opened %#v, got error %#v, want %#v", test.name, err, test.err)
 			}
 
@@ -105,7 +105,7 @@ func TestReadFile(t *testing.T) {
 		for _, test := range tests {
 			b, err := gfs.ReadFile(test.name)
 
-			if err != test.err {
+			if test.err != nil && !errors.Is(err, test.err) {
 				t.Fatalf("Read file %#v, got error %#v, want %#v", test.name, err, test.err)
 			}
 
@@ -144,16 +144,6 @@ func TestRead(t *testing.T) {
 
 		if got, want := string(b), "foobar\n"; got != want {
 			t.Fatalf("Read %d bytes in b (%#v), want %#v", n, got, want)
-		}
-	})
-
-	t.Run("Read NOK nil file", func(t *testing.T) {
-		b := make([]byte, len("foobar\n"))
-		var f *file = nil
-		_, err := f.Read(b)
-
-		if got, want := err, fs.ErrInvalid; got != want {
-			t.Fatalf("Read on a nil file and got %#v, want %#v", got, want)
 		}
 	})
 
@@ -244,15 +234,6 @@ func TestStat(t *testing.T) {
 					t.Fatal("got Sys with type different from *github.GistFile, want it to be the case")
 				}
 			}
-		}
-	})
-
-	t.Run("Stat NOK nil file", func(t *testing.T) {
-		var f *file = nil
-		_, err := f.Stat()
-
-		if got, want := err, fs.ErrInvalid; got != want {
-			t.Fatalf("Read on a nil file and got %#v, want %#v", got, want)
 		}
 	})
 

--- a/gistfs_test.go
+++ b/gistfs_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var referenceGistID = "ded2f6727d98e6b0095e62a7813aa7cf"
+var approxModTime, _ = time.Parse("2000-12-31", "2020-01-02") // when the gist was last edited
 
 // Avoid burning rate limit by using a caching http client.
 func cachingClient() *github.Client {
@@ -177,7 +178,6 @@ func TestStat(t *testing.T) {
 	gfs.Load(context.Background())
 
 	t.Run("Stat OK", func(t *testing.T) {
-		approxModTime, _ := time.Parse("2000-12-31", "2020-01-02") // when the gist was last edited
 
 		tests := []struct {
 			filename      string
@@ -239,8 +239,9 @@ func TestStat(t *testing.T) {
 					t.Fatalf("got isDir %#v, want %#v", got, want)
 				}
 
-				if got, want := stat.Sys(), f; got != want {
-					t.Fatalf("got Sys %#v, want %#v", got, want)
+				_, ok := stat.Sys().(*github.GistFile)
+				if got, want := ok, true; got != want {
+					t.Fatal("got Sys with type different from *github.GistFile, want it to be the case")
 				}
 			}
 		}
@@ -266,6 +267,115 @@ func TestStat(t *testing.T) {
 
 		if got, want := err, fs.ErrClosed; got != want {
 			t.Fatalf("Read on a closed file and got %#v, want %#v", got, want)
+		}
+	})
+}
+
+func TestReadDir(t *testing.T) {
+	gfs := NewWithClient(cacheClient, referenceGistID)
+	gfs.Load(context.Background())
+
+	t.Run("OK", func(t *testing.T) {
+		file, err := gfs.Open(".")
+		if err != nil {
+			t.Fatalf("Opening root directory, expected no error but got %#v", err)
+		}
+
+		dir, ok := file.(fs.ReadDirFile)
+		if !ok {
+			t.Fatal("Reading root directory, expected a ReadDirFile but got something else")
+		}
+
+		files, err := dir.ReadDir(-1)
+		if err != nil {
+			t.Fatalf("Reading root directory, expected no error but got %#v", err)
+		}
+
+		if got, want := len(files), 2; got != want {
+			t.Fatalf("Reading root directory, got %#v files, want %#v", got, want)
+		}
+	})
+
+	t.Run("OK subsequent reads", func(t *testing.T) {
+		file, err := gfs.Open(".")
+		if err != nil {
+			t.Fatalf("Opening root directory, expected no error but got %#v", err)
+		}
+
+		dir, ok := file.(fs.ReadDirFile)
+		if !ok {
+			t.Fatal("Reading root directory, expected a ReadDirFile but got something else")
+		}
+
+		// first read
+		files, err := dir.ReadDir(1)
+		if err != nil {
+			t.Fatalf("Reading root directory, expected no error but got %#v", err)
+		}
+
+		if got, want := len(files), 1; got != want {
+			t.Fatalf("Reading root directory, got %#v files, want %#v", got, want)
+		}
+
+		// second read
+		files, err = dir.ReadDir(1)
+		if err != nil {
+			t.Fatalf("Reading root directory, expected no error but got %#v", err)
+		}
+
+		if got, want := len(files), 1; got != want {
+			t.Fatalf("Reading root directory, got %#v files, want %#v", got, want)
+		}
+
+		// last read (no entries left)
+		files, err = dir.ReadDir(1)
+		if err != nil {
+			t.Fatalf("Reading root directory, expected no error but got %#v", err)
+		}
+
+		if got, want := len(files), 0; got != want {
+			t.Fatalf("Reading root directory, got %#v files, want %#v", got, want)
+		}
+	})
+
+	t.Run("OK ReadDir", func(t *testing.T) {
+		files, err := gfs.ReadDir(".")
+		if err != nil {
+			t.Fatalf("Reading root directory, expected no error but got %#v", err)
+		}
+
+		if got, want := len(files), 2; got != want {
+			t.Fatalf("Reading root directory, got %#v files, want %#v", got, want)
+		}
+	})
+
+	t.Run("OK Stat", func(t *testing.T) {
+		file, err := gfs.Open(".")
+		if err != nil {
+			t.Fatalf("Opening root directory, expected no error but got %#v", err)
+		}
+
+		dir, ok := file.(fs.ReadDirFile)
+		if !ok {
+			t.Fatal("Reading root directory, expected a ReadDirFile but got something else")
+		}
+
+		stat, err := dir.Stat()
+		if err != nil {
+			t.Fatalf("Getting stat of root directory, expected no error but got %#v", err)
+		}
+
+		if got, want := stat.Name(), "./"; got != want {
+			t.Fatalf("Reading name of root directory, got %#v files, want %#v", got, want)
+		}
+
+		if got, want := stat.ModTime(), approxModTime; got.After(approxModTime) &&
+			got.Before(approxModTime.Add(24*time.Hour)) {
+			t.Fatalf("got modTime %#v, want approx %#v", got, want)
+		}
+
+		if got, want := stat.IsDir(), true; got != want {
+			t.Fatalf("got isDir %#v, want %#v", got, want)
 		}
 	})
 }

--- a/gistfs_test.go
+++ b/gistfs_test.go
@@ -330,6 +330,43 @@ func TestReadDir(t *testing.T) {
 		}
 	})
 
+	t.Run("NOK ReadDir on a file", func(t *testing.T) {
+		file, err := gfs.Open("test1.txt")
+		if err != nil {
+			t.Fatalf("Opening root directory, expected no error but got %#v", err)
+		}
+
+		dir, ok := file.(fs.ReadDirFile)
+		if !ok {
+			t.Fatal("Reading root directory, expected a ReadDirFile but got something else")
+		}
+
+		_, err = dir.ReadDir(-1)
+
+		if _, ok := err.(*fs.PathError); !ok {
+			t.Fatalf("Reading directory on a file, got %#v error, want %#v", err, &fs.PathError{})
+		}
+	})
+
+	t.Run("NOK Read on a directory", func(t *testing.T) {
+		file, err := gfs.Open(".")
+		if err != nil {
+			t.Fatalf("Opening root directory, expected no error but got %#v", err)
+		}
+
+		dir, ok := file.(fs.ReadDirFile)
+		if !ok {
+			t.Fatal("Reading root directory, expected a ReadDirFile but got something else")
+		}
+
+		b := make([]byte, 1)
+		_, err = dir.Read(b)
+
+		if _, ok := err.(*fs.PathError); !ok {
+			t.Fatalf("Reading bytes on a directory, got %#v error, want %#v", err, &fs.PathError{})
+		}
+	})
+
 	t.Run("OK Stat", func(t *testing.T) {
 		file, err := gfs.Open(".")
 		if err != nil {

--- a/gistfs_test.go
+++ b/gistfs_test.go
@@ -34,14 +34,14 @@ func TestErrorNotLoaded(t *testing.T) {
 func TestNew(t *testing.T) {
 	t.Run("New OK", func(t *testing.T) {
 		gfs := New(referenceGistID)
-		if got, want := gfs.ID, referenceGistID; got != want {
+		if got, want := gfs.GetID(), referenceGistID; got != want {
 			t.Fatalf("New returned a FS with ID=%#v, want %#v", got, want)
 		}
 	})
 
 	t.Run("NewWithClient OK", func(t *testing.T) {
 		gfs := NewWithClient(cacheClient, referenceGistID)
-		if got, want := gfs.ID, referenceGistID; got != want {
+		if got, want := gfs.GetID(), referenceGistID; got != want {
 			t.Fatalf("NewWithClient returned a FS with ID=%#v, want %#v", got, want)
 		}
 	})


### PR DESCRIPTION
While working on #1 I went to simplify the code by dropping unnecessary structs. It's much better now. 

- [x] rebase the `fixup` commit 
- [x] make sure that all method of `*FS` have their receiver named `fsys` 
- [x] rework the errors using `PathError{Op: "read", ...}` to add more context  
- [x] add a test for `Read` / `ReadDir` on `*rootDir` / `*file`
- [x] write some doc 
- [x] add an example of ReadDir in the Readme 

And it'll be release time! 